### PR TITLE
Version 1.2: kang: Bump key requirements

### DIFF
--- a/Security/Fundamentals.mediawiki
+++ b/Security/Fundamentals.mediawiki
@@ -7,7 +7,8 @@ The goal of this document is to detail the rationales behind why various technol
 |-
 ! Document Status !! Major Versions
 |- 
-|  <span style="color:orange;">'''DRAFT'''</span> ||
+|  <span style="color:green;">'''READY'''</span> ||
+* Version 1.1: kang: r+
 * Version 1: gene: creation
 |}
 [[File:OpSec.png|right|300px]]
@@ -19,28 +20,48 @@ The goal of this document is to detail the rationales behind why various technol
 !Topic
 !Rationale
 |-
-|<div id="shared-passwords">[[#shared-passwords|§]] Shared passwords</div>
-|Shared passwords are passwords that more than one person knows or has access to. They're discouraged because
-* Use of them makes auditing access difficult because
-** multiple users appear in audit logs as one user and different users actions are difficult to differentiate
-** the number of audit logs that need to be searched increases
-** correlation of events across different systems is impossible if multiple people are creating event records with a single shared account across multiple systems at the same time
-* Revoking access to a subset of the users of a shared password requires a password change that affects all users
+|<div id="shared-passwords">[[#shared-passwords|§]] Shared passwords and accounts</div>
+|Shared passwords are passwords or/and accounts that more than one person knows or has access to. They're discouraged because
+* Use of them makes auditing access difficult:
+** multiple users appear in audit logs as one user and different users actions are difficult to differentiate.
+** the number of audit logs that need to be searched increases.
+** correlation of events across different systems is impossible if multiple people are creating event records with a
+single shared account across multiple systems at the same time.
+* Revoking access to a subset of the users of a shared password requires a password change that affects all users.
 |-
 |<div id="decentralized-user-account-management">[[#decentralized-user-account-management|§]] Decentralized user account management</div>
-|Decentralized user account management refers to user account management which is not driven by the source of truth for the user's account. Examples of this are
-* Manual user account creation by administrators
-* Automated user account creation from scripting or configuration management that creates accounts based on a static list of users
-This practice is discouraged because
-* When a user's access status changes due to leaving the company or changing teams, the associated change in the system which uses decentralized user account management is not automatically made resulting in unintended system access
-* When a user changes an attribute of their account in the centralized account management system, for example their email address or password, that change is not reflected in the systems which use decentralized user account management. Conversely when the user changes an attribute in the systems which use decentralized user account management, that change is not propagated to the centralized account management system.
+|Decentralized user account management refers to user account management which is not driven by the source of truth for
+the user's account. Examples of this are:
+* Manual user account creation by administrators.
+* Automated user account creation from scripting or configuration management that creates accounts based on a static
+* list of users.
+This practice is discouraged because:
+* When a user's access status changes due to leaving the company or changing teams, the associated change in the system
+* which uses decentralized user account management is not automatically made resulting in unintended system access.
+* When a user changes an attribute of their account in the centralized account management system, for example their
+* email address or password, that change is not reflected in the systems which use decentralized user account
+* management. Conversely when the user changes an attribute in the systems which use decentralized user account
+* management, that change is not propagated to the centralized account management system.
 |-
 |<div id="mfa">[[#mfa|§]] Multi-factor Authentication</div>
-|Multi-factor authentication (MFA) is a security system that requires more than one method of authentication from independent categories of credentials to verify the user's identity for a login or other transaction. Requiring the use of MFA for internet accessible endpoints is encouraged because by requiring not only something the user knows (a knowledge factor like a memorized password) but also something that the user has (a possession factor like a smartcard, yubikey or mobile phone) the field of threat actors that could compromise the account is reduced to actors with physical access to the user. In cases where the possession factor is digital (a secret stored in your mobile phone) instead of physical (a smartcard or yubikey), the effect of MFA is not to reduce the field of threat actors to only those that have physical access to the user, because a secret can be remotely copied off of a compromised mobile phone. Instead, in this case, the possession factor merely makes it more difficult for the threat actor since they now need to brute force/guess your password '''and''' compromise your mobile phone. This is, however, still possible to do entirely from a remote location.
+|Multi-factor authentication (MFA) is a security system that requires more than one method of authentication from
+independent categories of credentials to verify the user's identity for a login or other transaction.
+Requiring the use of MFA for internet accessible endpoints is encouraged because by requiring not only something the
+user knows (a knowledge factor like a memorized password) but also something that the user has (a possession factor like
+a smartcard, yubikey or mobile phone) the field of threat actors that could compromise the account is reduced to actors
+with physical access to the user.
+
+In cases where the possession factor is digital (a secret stored in your mobile phone) instead of physical (a smartcard
+or yubikey), the effect of MFA is not to reduce the field of threat actors to only those that have physical access to
+the user, because a secret can be remotely copied off of a compromised mobile phone. Instead, in this case, the
+possession factor merely makes it more difficult for the threat actor since they now need to brute force/guess your
+password '''and''' compromise your mobile phone. This is, however, still possible to do entirely from a remote location.
+In particular, storing both first on second factor on the same device (for example: mobile phone) is strongly discouraged.
 |-
 |<div id="nsm">[[#nsm|§]] Network Security Monitoring</div>
-|Network Security Monitoring (NSM) is the practice of monitoring raw network traffic in order to detect intrusions or abnormal behavior. The use of NSM is encouraged because it can
-* identify when a host has been compromised by the network traffic it emits
-* understand the commonalities in a distributed network attack
-* provide incident responders with data needed to quickly diagnose security issues
+|Network Security Monitoring (NSM) is the practice of monitoring raw network traffic in order to detect intrusions or
+abnormal behavior. The use of NSM is encouraged because it can:
+* identify when a host has been compromised by the network traffic it emits.
+* understand the commonalities in a distributed network attack.
+* provide incident responders with data needed to quickly diagnose security issues.
 |}

--- a/Security/Guidelines/Key_Management.mediawiki
+++ b/Security/Guidelines/Key_Management.mediawiki
@@ -9,6 +9,7 @@ The Operations Security (OpSec) team maintains this document as a reference guid
 ! Document Status !! Major Versions
 |- 
 |  <span style="color:orange;">'''DRAFT'''</span> ||
+* Version 1.2: kang: Bump key requirements see also <https://www.nsa.gov/ia/programs/suiteb_cryptography/index.shtml>, rationale: historically when the NSA has such high requirements they're aware of significant weaknesses with lower requirements.
 * Version 1.1: kang: migrated OpenSSH key handling to [[Security/Guidelines/OpenSSH]]
 * Version 1: kang/ulfr: creation
 |}
@@ -36,11 +37,11 @@ This section organizes algorithms and key sizes for a given validity period that
 |-
 | Asymmetric encryption || ECDSA 384 bits || 192 bits
 |-
-| Symmetric encryption || AES-GCM 192 bits || 192 bits
+| Symmetric encryption || AES-GCM 256 bits || 256 bits
 |- 
-| Hash & HMAC || SHA-384 || 192 bits
+| Hash & HMAC || SHA-512 || 256 bits
 |-
-| Hash & HMAC || SHA3-384 || 192 bits
+| Hash & HMAC || SHA3-512 || 256 bits
 |}
 
 == 2 years (default) ==
@@ -48,19 +49,20 @@ This section organizes algorithms and key sizes for a given validity period that
 |-
 ! Type !! Algorithm and key size !! Bits of security
 |-
-| Asymmetric keys || RSA 2048 bits || 112 bits
+| Asymmetric keys || RSA 3072 bits || 128 bits
 |-
-| Asymmetric keys || ECDSA 224 or 256 bits || 112 bits
+| Asymmetric keys || ECDSA 384 bits || 192 bits
 |-
-| Symmetric encryption || AES-CBC 128 bits || 128 bits
+| Symmetric encryption || AES-CBC 256 bits || 256 bits
 |-
-| Hash & HMAC || SHA-256 || 128 bits
+| Hash & HMAC || SHA-384 || 192 bits
 |-
-| Hash & HMAC || SHA3-256 || 128 bits
+| Hash & HMAC || SHA3-384 || 192 bits
 |}
 
 == Legacy, not recommended ==
-The following algorithms and sizes are still widely used but do not provide sufficient security for modern services and should be deprecated as soon as possible, unless backward compatibility is a strong requirement (even so, a deprecation planning should be setup).
+The following algorithms and sizes are still widely used but do not provide sufficient security for modern services and should be deprecated as soon as possible.
+
 {| class="wikitable"
 |-
 ! Type !! Algorithm and key size !! Bits of security
@@ -71,7 +73,7 @@ The following algorithms and sizes are still widely used but do not provide suff
 |-
 | Symmetric encryption || 3DES || 112 bits
 |-
-| Symmetric encryption || RC4 || 
+| Symmetric encryption || RC4 ||
 |-
 | Hash & HMAC || SHA-1 || 80 bits
 |-
@@ -118,14 +120,16 @@ Using long key ids over the default short key ids is also recommended. If possib
 
 File: ~/.gnupg/gpg.conf
 <source>
-personal-digest-preferences SHA512 SHA384 SHA256
+personal-digest-preferences SHA512 SHA384
 cert-digest-algo SHA256
-default-preference-list SHA512 SHA384 SHA256 SHA224 AES256 AES192 AES CAST5 ZLIB BZIP2 ZIP Uncompressed
+default-preference-list SHA512 SHA384 AES256 ZLIB BZIP2 ZIP Uncompressed
 keyid-format 0xlong
 </source>
 
 = Definitions =
 == Bits of security ==
 Security Bits estimate the computational steps or operations (not machine instructions) required to solve a cryptographic problem (i.e. crack the key/hash).
+Of course, these do not factor in weaknesses in the algorithms which would reduce the effective amount of security bits
+and therefore is only used as an indicator of the width of the total (maximum) space to exhaust to ensuring finding the key.
 
-For a more detailed definition, see http://en.wikipedia.org/wiki/Key_size and  http://www.cryptopp.com/wiki/Security_Level#Security_Bits.
+For a more detailed definition, see http://en.wikipedia.org/wiki/Key_size, https://en.wikipedia.org/wiki/Secure_Hash_Algorithm and  http://www.cryptopp.com/wiki/Security_Level#Security_Bits.

--- a/Security/Guidelines/Key_Management.mediawiki
+++ b/Security/Guidelines/Key_Management.mediawiki
@@ -26,16 +26,24 @@ Key material must be encrypted on transmission. Key material can be stored in cl
 Public certificates are public and do not require specific access control or encryption.
 
 = Algorithms by security levels =
-This section organizes algorithms and key sizes for a given validity period that represent the level of security provided. While 10 years validity may be a requirement for very static keys, such as Root CAs, we do recommend preferring 2 years keys and implementing reliable key rotation, instead of trying to keep key material for long periods of time.
+This section organizes algorithms and key sizes by rating (modern, intermediate, old) for a given validity period.
+Regardless of the rating choosen, we do recommend prefering 2 years keys with a reliable key rotation instead of trying
+to keep key material for long periods of time.
+This allow for faster operational reaction time when new algorithm weaknesses are discovered.
 
-== 10 years ==
+== Modern - 10 years (default) ==
+These may be used if expiring within 10 years and should be the default choice unless limited by technological factors
+such as client/server support or performance.
+
+Use of EC is favored over RSA for performances purposes.
+
 {| class="wikitable"
 |-
 ! Type !! Algorithm and key size !! Bits of security
 |-
 | Asymmetric encryption || RSA 4096 bits || 144 bits
 |-
-| Asymmetric encryption || ECDSA 384 bits || 192 bits
+| Asymmetric encryption || ECDSA 512 bits || 256 bits
 |-
 | Symmetric encryption || AES-GCM 256 bits || 256 bits
 |- 
@@ -44,23 +52,25 @@ This section organizes algorithms and key sizes for a given validity period that
 | Hash & HMAC || SHA3-512 || 256 bits
 |}
 
-== 2 years (default) ==
+== Intermediate - 2 years ==
+These maybe be used if expiring within 2 years or up to 2020 whichever comes first.
+
 {| class="wikitable"
 |-
 ! Type !! Algorithm and key size !! Bits of security
 |-
 | Asymmetric keys || RSA 3072 bits || 128 bits
 |-
-| Asymmetric keys || ECDSA 384 bits || 192 bits
+| Asymmetric keys || ECDSA 256 bits || 128 bits
 |-
-| Symmetric encryption || AES-CBC 256 bits || 256 bits
+| Symmetric encryption || AES-CBC 128 bits || 128 bits
 |-
-| Hash & HMAC || SHA-384 || 192 bits
+| Hash & HMAC || SHA-256 || 128 bits
 |-
-| Hash & HMAC || SHA3-384 || 192 bits
+| Hash & HMAC || SHA3-256 || 128 bits
 |}
 
-== Legacy, not recommended ==
+== Old - do not use ==
 The following algorithms and sizes are still widely used but do not provide sufficient security for modern services and should be deprecated as soon as possible.
 
 {| class="wikitable"


### PR DESCRIPTION
Ok, this is a big one:
This PR boosts the key sizes, algorithms key sizes for 2 years usage according to the new and fresh NSA recommendations. It also ensure all 10 years keys and hashes are going above NSA recommendations.

see also <https://www.nsa.gov/ia/programs/suiteb_cryptography/index.shtml>
rationale: historically when the NSA has such high requirements they're aware of significant weaknesses with lower requirements (for the younger among us, Google the DES story).

Why this may be controversial:
* this makes algorithm requirements significantly higher than current best-practices for certain algorithms, but I expect best-practices are going to be what we set here
* following NSA recommendations is generally not seen as "safest" option - however...
a) these are the algorithms our products currently support, until everyone implements alternatives as well
b) these are HIGHER than our current defaults anyway, which is slightly scary "anyway"

I'd like a few r? for this one instead of the single peer review we usually do.

Discuss away ;-)