### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+sync.json


### PR DESCRIPTION
This adds a .gitignore file that tells git not to see changes to sync.json as a change that should be committed.  This will reduce the likelihood that someone makes a mistake and commits their sync.json file to the git repo, which would contain their wikimo web UI creds.